### PR TITLE
Adding ability to upload screenshot as attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ TESTRAIL_PASSWORD=
 TESTRAIL_PROJECTID=
 ```
 
-If these variables are present, we assume the user wants to use the plugin. You can disable the plugin by passing an argument
+If these variables are present, we assume the user wants to use the plugin. You can disable the plugin by passing an argument.
+
+Additionally, if you want the ability to close a testrun with untested test cases, you could set 
+```
+TESTRAIL_ALLOW_CLOSING_PARTIAL_RUN=true
+```
+This will allow the `npx testrail-close-run` command to close a testrun with untested test cases.
 
 ```js
 module.exports = (on, config) => {

--- a/bin/testrail-close-run.js
+++ b/bin/testrail-close-run.js
@@ -3,7 +3,7 @@
 // @ts-check
 
 const debug = require('debug')('cypress-testrail-simple')
-const { getTestRunId, getTestRailConfig } = require('../src/get-config')
+const { getTestRunId, getTestRailConfig, allowClosingPartialTestRun } = require('../src/get-config')
 const { getTestRun, closeTestRun } = require('../src/testrail-api')
 
 let runId
@@ -32,7 +32,7 @@ getTestRun(runId, testRailInfo).then((runInfo) => {
   }
 
   const allTestsDone = runInfo.untested_count === 0
-  if (!allTestsDone) {
+  if (!allTestsDone && !allowClosingPartialTestRun()) {
     console.log(
       'TestRail run %d still has %d untested cases',
       runId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,19 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@cypress/xvfb": {
@@ -685,8 +698,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -961,7 +973,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1265,8 +1276,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -1530,13 +1540,12 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
@@ -2431,14 +2440,12 @@
     "mime-db": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "dev": true
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
     },
     "mime-types": {
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "dev": true,
       "requires": {
         "mime-db": "1.51.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "arg": "^5.0.1",
     "debug": "^4.3.2",
+    "form-data": "^4.0.0",
     "globby": "^11",
     "got": "^11.8.2"
   }

--- a/src/get-config.js
+++ b/src/get-config.js
@@ -64,9 +64,24 @@ function getTestRunId(env = process.env) {
   debug('could not find runId.txt in folder %s', process.cwd())
 }
 
+// Allows users to set the TESTRAIL_ALLOW_CLOSING_PARTIAL_RUN
+// environment variable to allow closing a test run even with
+// untested tests. The main plugin only allows closing a testrun
+// only when all the tests within that testrun are completed (either 
+// passed or failed). Having this options gives a little flexibility
+// Where we add test cases in testrail and gradually write the corrosponding
+// Cypress tests.
+function allowClosingPartialTestRun(env = process.env) {
+  if ('TESTRAIL_ALLOW_CLOSING_PARTIAL_RUN' in env) {
+    return true;
+  }
+  return false;
+}
+
 module.exports = {
   hasConfig,
   getTestRailConfig,
   getAuthorization,
   getTestRunId,
+  allowClosingPartialTestRun
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,8 +9,36 @@ const {
   getAuthorization,
   getTestRunId,
 } = require('../src/get-config')
+const FormData = require('form-data')
+const fs = require('fs')
 
-async function sendTestResults(testRailInfo, runId, testResults) {
+// If a test fails, the screenshot path is added as an attachment to the result.
+async function uploadAttachmentToResult(testRailInfo, resultId, screenshotPath) {
+  try {
+    if (!fs.existsSync(screenshotPath)) {
+      return;
+    }
+    const addResultsUrl = `${testRailInfo.host}/index.php?/api/v2/add_attachment_to_result/${resultId}`;
+    const authorization = getAuthorization(testRailInfo);
+
+    const form = new FormData();
+    form.append('attachment', fs.createReadStream(screenshotPath));
+    // @ts-ignore
+    await got(addResultsUrl, {
+      method: 'POST',
+      headers: {
+        ...form.getHeaders(),
+        authorization,
+      },
+      body: form,
+    });
+  } catch(err) {
+    debug('Attachment upload failed');
+    console.log(err);
+  }
+}
+
+async function sendTestResults(testRailInfo, runId, testResults, screenshotPath) {
   debug(
     'sending %d test results to TestRail for run %d',
     testResults.length,
@@ -30,6 +58,14 @@ async function sendTestResults(testRailInfo, runId, testResults) {
       results: testResults,
     },
   }).json()
+
+  if(Array.isArray(json) && json.length > 0) {
+    const resultObj = json[0];
+    const resultId = resultObj.id;
+    if (screenshotPath) {
+      await uploadAttachmentToResult(testRailInfo, resultId, screenshotPath);
+    }
+  }
 
   debug('TestRail response: %o', json)
 }
@@ -76,13 +112,15 @@ function registerPlugin(on, skipPlugin = false) {
 
     // find only the tests with TestRail case id in the test name
     const testRailResults = []
+    let screenshotPath = "";
     results.tests.forEach((result) => {
       const testRailCaseReg = /C(\d+)\s/
       // only look at the test name, not at the suite titles
       const testName = result.title[result.title.length - 1]
       if (testRailCaseReg.test(testName)) {
+        const caseId = parseInt(testRailCaseReg.exec(testName)[1]);
         const testRailResult = {
-          case_id: parseInt(testRailCaseReg.exec(testName)[1]),
+          case_id: caseId,
           // TestRail status
           // Passed = 1,
           // Blocked = 2,
@@ -93,12 +131,46 @@ function registerPlugin(on, skipPlugin = false) {
           // https://glebbahmutov.com/blog/cypress-test-statuses/
           status_id: result.state === 'passed' ? 1 : 5,
         }
+
+        if(result.state !== "passed") {
+          // If the test fails, attach the test title, body and displayError
+          // messages as a comment to the test result.
+          if(result && result.title && result.body && result.displayError) {
+            testRailResult.comment = `
+              Error Message: \n
+              ${result.title.join("--")} failed.\n 
+              Error body: \n
+              ${result.body}.\n
+              Error stacktrace: \n 
+              ${result.displayError}`;
+          }
+
+          // Find the screenshot path for the failed test and store it to add
+          // it as an attachment.
+          if("screenshots" in results) {
+            // @ts-ignore
+            if(Array.isArray(results.screenshots)) {
+              // @ts-ignore
+              const screenshotObj = results.screenshots.find((screenshot) => {
+                return screenshot.path.indexOf(`C${caseId}`) !== -1;
+              });
+              screenshotPath = screenshotObj.path;
+            }
+          }
+        }
+
         testRailResults.push(testRailResult)
       }
     })
     if (testRailResults.length) {
-      console.log('TestRail results in %s', spec.relative)
-      console.table(testRailResults)
+      console.log('TestRail results in %s', spec.relative);
+      const testResultTableOutput = testRailResults.map((testRailResultObj) => {
+        return {
+          case_id: testRailResultObj.case_id,
+          status_id: testRailResultObj.status_id
+        };
+      });
+      console.table(testResultTableOutput);
       return sendTestResults(testRailInfo, runId, testRailResults)
     }
   })


### PR DESCRIPTION
## Summary

The main `cypress-testrail-simple` plugin does not support:
-  Uploading a screenshot as an attachment to the test run result if a test fails
-  Adding a comment to the test result
- Allow closing a test run with untested test cases

## Solution

This PR :
- exposes `TESTRAIL_ALLOW_CLOSING_PARTIAL_RUN` environment variable, which when set, allows closing a testrun with untested testcases
- Adds support to upload a screenshot and add a error stack trace/message when the test fails.
- Update docs
